### PR TITLE
Add check to prevent crashes

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -49,8 +49,9 @@ class BunyanLumberjackStream extends Writable
         entry.message = entry.msg ? ''
         delete entry.msg
 
-        entry['@timestamp'] = entry.time.toISOString()
-        delete entry.time
+        if entry.time?
+            entry['@timestamp'] = entry.time.toISOString()
+            delete entry.time
 
         delete entry.v
 


### PR DESCRIPTION
Not all logs are required to have a time parameter.
