### PR TITLE
add support for metadata on app & item level

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Features
 * Generated entries in logstash are identical to what would be produced by
   [bunyan-logstash-tcp](https://github.com/chris-rock/bunyan-logstash-tcp), making it easy to
   switch from one to the other.
+* Support for @metadata on app & item level (with _md shorthand)
 
 There are alternatives to this package if you don't need/want encryption:
 
@@ -50,7 +51,8 @@ complere end-to-end setup, but the basics are:
                         // If we have to drop logs, drop INFO level logs and lower - keep errors.
                         return logEntry.level <= bunyan.INFO
                     }
-                }
+                },
+                metadata:{beat:"example",type:"default"}
             })
         }]
     });
@@ -88,6 +90,10 @@ The name to use for the application in the `source` field.  Defaults to `process
 ### type
 
 If specified, will be added to the entry before being sent to logstash.  Defaults to 'json'.
+
+### metadata
+
+If specified, will be added to the entry before being sent to logstash.  Can be used for extra parameters that will stay within logstash (logstash will not forward these to elasticsearch).  Defaults to empty object.
 
 Tutorial
 ========
@@ -174,7 +180,8 @@ On the client side, we need a copy of the `logstash.crt` file we just created, t
             host: 'logstash.mycorp.com',
             port: 5000,
             ca: [fs.readFileSync('path/to/logstash.crt', {encoding: 'utf-8'})]
-        }
+        },
+        metadata:{beat:"lowercase-name",type:"default"}
     });
 
     outStream.on('connect', function() {
@@ -193,3 +200,5 @@ On the client side, we need a copy of the `logstash.crt` file we just created, t
     });
 
     log.info("This should work!");
+    
+    log.info({_md:{type:"custom"}},"Item-based custom metadata!");

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -72,6 +72,10 @@ class BunyanLumberjackStream extends Writable
 
         # Add some extra fields
         entry.tags ?= @_tags
+        
+        if entry._md
+          entry["@metadata"] = entry._md
+          delete entry._md
         unless entry["@metadata"]?
           entry["@metadata"] = @_metadata
         else

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -17,6 +17,20 @@ clone = (obj) ->
     answer[key] = value for key, value of obj
     return answer
 
+###
+Overwrites obj1's values with obj2's and adds obj2's if non existent in obj1
+@param obj1
+@param obj2
+@returns obj3 a new object based on obj1 and obj2
+###
+merge_options = (obj1, obj2) ->
+  obj3 = {}
+  for attrname of obj1
+    obj3[attrname] = obj1[attrname]
+  for attrname of obj2
+    obj3[attrname] = obj2[attrname]
+  obj3
+
 class BunyanLumberjackStream extends Writable
     constructor: (tlsOptions, lumberjackOptions={}, options={}) ->
         super {objectMode: true}
@@ -31,6 +45,7 @@ class BunyanLumberjackStream extends Writable
         @_tags = options.tags ? ['bunyan']
         @_type = options.type ? 'json'
         @_application = options.appName ? process.title
+        @_metadata = options.metadata ? {}
 
         @on 'finish', =>
             @_client.close()
@@ -57,6 +72,10 @@ class BunyanLumberjackStream extends Writable
 
         # Add some extra fields
         entry.tags ?= @_tags
+        unless entry["@metadata"]?
+          entry["@metadata"] = @_metadata
+        else
+          entry["@metadata"] = merge_options(@_metadata, entry["@metadata"])
         entry.source = "#{host}/#{@_application}"
 
         dataFrame = {


### PR DESCRIPTION
Since the @metadata field is quite useful and actually is being used by default configurations (depending on installation method of the elk stack) for the beat & type fields (to form the _index & _type fields I've modified the script to support metadata fields on both app & item level: item fields override app level fields

example usage:

```
bunyanLumberjackStream({
  metadata: {beat:"example",type:"test"}
}
...
log.info("meta-test")// will have the app's default metadata sent along
  log.info({"@metadata":{type:"testing"}},"meta-type-test") // beat will be example, type will be testing instead of test
```
